### PR TITLE
Do not cut git describe in custom release builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,9 @@ ifneq (,$(shell git describe --exact-match --tags 2>/dev/null))
 	GLUON_RELEASE := $(shell git describe --tags 2>/dev/null)
 else
 	GLUON_AUTOUPDATER_ENABLED := 0
-	EXP_FALLBACK = $(shell date '+%Y%m%d%H')
+	EXP_FALLBACK = $(shell date '+%Y%m%d')
 	BUILD_NUMBER ?= $(EXP_FALLBACK)
-	GLUON_RELEASE := $(shell git describe --tags | cut -d- -f1)~next$(BUILD_NUMBER)
+	GLUON_RELEASE := $(shell git describe --tags)~exp$(BUILD_NUMBER)
 endif
 
 JOBS ?= $(shell cat /proc/cpuinfo | grep processor | wc -l)


### PR DESCRIPTION
Currently, if autoupdate is enabled on a custom next build, it will
automatically downgrade to the latest release.

For example:
One commit on top of latest release "v2021.8.1-next1"

```
Before: v2021.8.1~next2021083100
After:  v2021.8.1-next1-1-g2f13e5e~exp20210831
```